### PR TITLE
Update opencv.spec

### DIFF
--- a/opencv.spec
+++ b/opencv.spec
@@ -65,7 +65,7 @@ BuildRequires:	%{_lib}opencl-devel
 BuildRequires:	protobuf-compiler
 BuildRequires:	pkgconfig(protobuf)
 %if %{with python}
-BuildRequires:	python-numpy-devel >= 1.16.5
+BuildRequires:	python3-numpy-devel >= 1.16.5
 BuildRequires:	python2-numpy-devel >= 1.16.5
 BuildRequires:	pkgconfig(python2)
 BuildRequires:	pkgconfig(python3)


### PR DESCRIPTION
force python3-numpy-devel because version without "3" in name causing issues on armv7